### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Publish to Docker Hub
 on:
   push:
@@ -8,20 +9,28 @@ env:
   FRONT_IMAGE_NAME: ${{ github.repository }}-frontend
   BACK_IMAGE_NAME: ${{ github.repository }}-backend
   DATABASE_IMAGE_NAME: ${{ github.repository }}-database
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 
 jobs:
   push-front-to-registry:
     name: Publish frontend image to Docker Hub
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Log into Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ steps.esc-secrets.outputs.DOCKERHUB_USERNAME }}
+          password: ${{ steps.esc-secrets.outputs.DOCKERHUB_TOKEN }}
 
       - name: Add front metadata for Docker Hub
         id: meta-front
@@ -31,9 +40,10 @@ jobs:
           flavor: |
             latest=true
             
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -50,14 +60,17 @@ jobs:
     name: Publish backend image to Docker Hub
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Log into Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ steps.esc-secrets.outputs.DOCKERHUB_USERNAME }}
+          password: ${{ steps.esc-secrets.outputs.DOCKERHUB_TOKEN }}
 
       - name: Add back metadata for Docker Hub
         id: meta-back
@@ -67,9 +80,10 @@ jobs:
           flavor: |
             latest=true
             
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -86,14 +100,17 @@ jobs:
     name: Publish database image to Docker Hub
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Log into Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ steps.esc-secrets.outputs.DOCKERHUB_USERNAME }}
+          password: ${{ steps.esc-secrets.outputs.DOCKERHUB_TOKEN }}
 
       - name: Add data metadata for Docker Hub
         id: meta-data
@@ -103,9 +120,10 @@ jobs:
           flavor: |
             latest=true
             
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
